### PR TITLE
Remove /sweepo URL suffix from application routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sweepo-react",
   "version": "1.0.0",
   "description": "Sweepo - Professional Cleaning Services Website",
-  "homepage": "/sweepo",
+  "homepage": "/",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.4",

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
     <React.StrictMode>
         <HelmetProvider>
-            <BrowserRouter basename="/sweepo">
+            <BrowserRouter>
                 <App />
             </BrowserRouter>
         </HelmetProvider>


### PR DESCRIPTION
- Removed basename='/sweepo' from BrowserRouter in src/index.js
- Updated homepage from '/sweepo' to '/' in package.json
- Application now works at root URL without requiring /sweepo suffix
- Changes apply to both development and production builds