### PR TITLE
Update QuoteModal to use localhost:5000 API endpoint

### DIFF
--- a/src/components/forms/QuoteModal.jsx
+++ b/src/components/forms/QuoteModal.jsx
@@ -24,7 +24,7 @@ const QuoteModal = () => {
     // This prevents the useForm hook from being recreated unnecessarily
     const handleSubmit = useMemo(() => async (formData) => {
         try {
-            const response = await fetch('/api/quote', {
+            const response = await fetch('http://localhost:5000/api/quote', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',


### PR DESCRIPTION
- Changed fetch URL from '/api/quote' to 'http://localhost:5000/api/quote'
- Ensures form submissions are sent to the correct backend server