### PR TITLE
Update phone validation and add development proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Sweepo - Professional Cleaning Services Website",
   "homepage": "/",
   "private": true,
+  "proxy": "http://localhost:1969",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -27,8 +27,11 @@ export const useForm = (initialValues, onSubmit) => {
     };
 
     const validatePhone = (phone) => {
-        const re = /^[\+]?[1-9][\d]{0,15}$/;
-        return re.test(phone.replace(/\s/g, ''));
+        // Remove spaces, dashes, parentheses, and plus signs for validation
+        const cleanPhone = phone.replace(/[\s\-\(\)\+]/g, '');
+        // Check if remaining characters are all digits
+        const re = /^\d+$/;
+        return re.test(cleanPhone) && cleanPhone.length > 0;
     };
 
     const validate = () => {


### PR DESCRIPTION
- Simplified phone validation to only check for numeric characters
- Added proxy configuration in package.json for development API requests
- Phone validation now accepts various formats (spaces, dashes, parentheses)
- Development server will now proxy /api requests to localhost:1969